### PR TITLE
Error on /bluedragon/administrator/

### DIFF
--- a/bluedragon/administrator/Application.cfc
+++ b/bluedragon/administrator/Application.cfc
@@ -146,7 +146,7 @@
 			</cfif>
 
 			<cfif !getPageContext().getRequest().getRequestURI() contains "login.cfm">
-				<cfset session.targetUrl = getPageContext().getRequest().getRootURL().toString() & getPageContext().getRequest().getRequestURI()>
+				<cfset session.targetUrl = getPageContext().getRequest().getContextPath() & getPageContext().getRequest().getRequestURI()>
 			</cfif>
 			<cflocation url="#contextPath#/bluedragon/administrator/login.cfm" addtoken="false" />
 		</cfif>


### PR DESCRIPTION
Accessing the Administration with /bluedragon/administrator/ only threw an error of:
```
Method getRootURL could not be found. Check you have correct method name, the method name casing matches that of the Java class and you've provided the correct number of arguments
```

The method obviously does not exists. I've fixed the code to work with the getContextPath(). Tested on MacOS X and Linux servers.