### PR TITLE
Removed unnecessary requests to get root path

### DIFF
--- a/bluedragon/administrator/Application.cfc
+++ b/bluedragon/administrator/Application.cfc
@@ -146,7 +146,8 @@
 			</cfif>
 
 			<cfif !getPageContext().getRequest().getRequestURI() contains "login.cfm">
-				<cfset session.targetUrl = getPageContext().getRequest().getContextPath() & getPageContext().getRequest().getRequestURI()>
+				<!--- <cfset session.targetUrl = getPageContext().getRequest().getContextPath() & getPageContext().getRequest().getRequestURI()> --->
+				<cfset session.targetUrl = getPageContext().getRequest().getRequestURI()>
 			</cfif>
 			<cflocation url="#contextPath#/bluedragon/administrator/login.cfm" addtoken="false" />
 		</cfif>


### PR DESCRIPTION
Upon my last change and deployment I saw that once the user is logged in it takes him to a URL, e.g.:
```
localhost/razuna/razuna/bluedragon/.....
```
This is because in the code on line 149 the request to the root path is done two times. Not exactly sure why this was done, but simply calling:
```
getPageContext().getRequest().getRequestURI()
```

is sufficient enough. I deployed this code already to a lot of customers and it works.
